### PR TITLE
Updating Tests

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -8,7 +8,7 @@ extends 'Dist::Zilla::Plugin::MakeMaker::Awesome';
 override _build_MakeFile_PL_template => sub {
 	my ($self) = @_;
 	my $template  = "use Devel::CheckLib;\n";
-	$template .= "check_lib_or_exit(libpath => '/usr/lib/llvm-3.3/lib', lib => 'clang');\n";
+	$template .= "check_lib_or_exit(libpath => '/usr/lib/llvm-3.5/lib', lib => 'clang');\n";
 
 	return $template.super();
 };
@@ -16,8 +16,8 @@ override _build_MakeFile_PL_template => sub {
 override _build_WriteMakefile_args => sub {
 	return +{
 		%{ super() },
-		LIBS	=> '-L/usr/lib/llvm-3.3/lib -lclang',
-		INC	=> '-I. -I/usr/lib/llvm-3.3/include',
+		LIBS	=> '-L/usr/lib/llvm-3.5/lib -lclang',
+		INC	=> '-I. -I/usr/lib/llvm-3.5/include',
 		OBJECT	=> '$(O_FILES)',
 	}
 };

--- a/t/02-cursor.t
+++ b/t/02-cursor.t
@@ -15,9 +15,6 @@ my $cursors = $cursr -> children;
 
 my @spellings = map { $_ -> spelling } @$cursors;
 my @expected  = qw(
-	__int128_t
-	__uint128_t
-	__builtin_va_list
 	foo
 	main
 );
@@ -29,9 +26,6 @@ is($file, ''); is($line, 0); is($column, 0);
 
 my @locations = map { join ' ', $_ -> location } @$cursors;
 @expected     = (
-	' 0 0',
-	' 0 0',
-	' 0 0',
 	't/test.c 1 6',
 	't/test.c 7 5'
 );

--- a/t/03-cursorkind.t
+++ b/t/03-cursorkind.t
@@ -15,9 +15,6 @@ my $cursors = $cursr -> children;
 
 my @spellings = map { $_ -> kind -> spelling } @$cursors;
 my @expected  = qw(
-	TypedefDecl
-	TypedefDecl
-	TypedefDecl
 	FunctionDecl
 	FunctionDecl
 );

--- a/t/05-typekind.t
+++ b/t/05-typekind.t
@@ -14,9 +14,6 @@ my $cursors = $cursr -> children;
 
 my @spellings = map { $_ -> type -> kind -> spelling } @$cursors;
 my @expected  = qw(
-	Typedef
-	Typedef
-	Typedef
 	FunctionProto
 	FunctionProto
 );


### PR DESCRIPTION
Updating tests for libclang-common-3.5-dev

The atual package of libclang (libclang-common-3.5-dev) do not return internal declarations by default, we remove it from the tests.

Signed-off-by: Alexandre Barbosa alexandreab@live.com
Signed-off-by: Lucas Kanashiro lucas-kanashiro@live.com
